### PR TITLE
Fix Footer Issue for GovWallet Factsheet

### DIFF
--- a/media-hub/press-releases/_posts/2022-03-02-post-GovWallet (Factsheet).md
+++ b/media-hub/press-releases/_posts/2022-03-02-post-GovWallet (Factsheet).md
@@ -8,7 +8,6 @@ description: GovWallet is an e-wallet feature that Government agencies can use
 image: /images/og-image/Smart-Nation-OG-Image.jpg
 ---
 
-
 ## Factsheet – GovWallet
 
 **2 Mar 2022**
@@ -34,13 +33,14 @@ Another collaboration is the creation of GovCash with the Central Provident Fund
 ### What’s next?
 
 To provide even more spending options for citizens, the GovWallet team is looking to tap on the NETs payment ecosystem which has over 120,000 acceptance points across 42,000 merchants in Singapore.
-_______
+
+---
 
 #### Annex A: Screenshot of the GovWallet feature
 
-<div style="width:50%;height:50%;"><img src="/images/media-hub/press-release/2022/Screenshot-of-the-GovWallet-feature.jpg" alt="Screenshot of the GovWallet feature."></div>
+<div style="width:50%;"><img src="/images/media-hub/press-release/2022/Screenshot-of-the-GovWallet-feature.jpg" alt="Screenshot of the GovWallet feature."></div>
 
-_______
+---
 
 **For media enquiries, please contact:**
 


### PR DESCRIPTION
Found an issue where the contact details is overlap with the footer section.
Site affected: https://www.smartnation.gov.sg/media-hub/press-releases/govwallet-factsheet-02032022

Resolution: remove `height: 50%`

<img width="2037" alt="contact-overlay-on-footer" src="https://user-images.githubusercontent.com/5835321/186852187-cf9e79bd-b652-48f2-9492-eb5cd7538d5e.png">
<img width="1898" alt="contact-overlay-after-fix" src="https://user-images.githubusercontent.com/5835321/186852190-56ae7048-4818-463a-b535-ee787ec329cf.png">

